### PR TITLE
Update ProductType.rebuild_ancestry to work with mysql2

### DIFF
--- a/arboreal.gemspec
+++ b/arboreal.gemspec
@@ -8,11 +8,9 @@ Arboreal surfaces relationships within the tree like "children", "ancestors", "d
 as scopes, so that additional filtering/pagination can be performed.
 TEXT
 
-require 'lib/arboreal/version'
-
 Gem::Specification.new do |s|
   s.name             = "arboreal"
-  s.version          = Arboreal::VERSION.dup
+  s.version          = "0.1.1"
   s.platform         = Gem::Platform::RUBY
   s.required_ruby_version = ">= 1.8.7"
   s.summary          = "Efficient tree structures for ActiveRecord"

--- a/lib/arboreal/class_methods.rb
+++ b/lib/arboreal/class_methods.rb
@@ -32,7 +32,7 @@ module Arboreal
     # As a result, this *may* not work for DBMS that aren't explicitly supported.
     #
     def ancestry_extension_sql
-      sql = if connection.adapter_name == "MySQL"
+      sql = if connection.adapter_name =~ /mysql/i
         <<-SQL
           UPDATE _arboreals_ AS child
           JOIN _arboreals_ AS parent ON parent.id = child.parent_id


### PR DESCRIPTION
This one line fix lets ProductType.rebuild_ancestry work with mysql2 and rails3
