### PR TITLE
Rails 3.0/3.1 compatability

### DIFF
--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -19,9 +19,7 @@ module Arboreal
       before_save :detect_ancestry_change
       after_save  :apply_ancestry_change_to_descendants
       
-      named_scope :roots, {
-        :conditions => ["parent_id IS NULL"]
-      }
+      scope :roots, where("parent_id IS NULL")
       
     end
     


### PR DESCRIPTION
named_scope doesn't exist in rails 3.1, so this patch changes it to scope instead.

This breaks compatibility for rails 2.x, but that's not really an issue for me. Feel free to ignore this request if rails 2.x support is important.
